### PR TITLE
String tags with cache

### DIFF
--- a/src/coroutine/make.lua
+++ b/src/coroutine/make.lua
@@ -1,20 +1,37 @@
-local select      = select
-local create      = coroutine.create
-local isyieldable = coroutine.isyieldable -- luacheck: ignore
-local resume      = coroutine.resume
-local running     = coroutine.running
-local status      = coroutine.status
-local wrap        = coroutine.wrap
-local yield       = coroutine.yield
+local select       = select
+local setmetatable = setmetatable
+local create       = coroutine.create
+local isyieldable  = coroutine.isyieldable -- luacheck: ignore
+local resume       = coroutine.resume
+local running      = coroutine.running
+local status       = coroutine.status
+local wrap         = coroutine.wrap
+local yield        = coroutine.yield
 
-return function (tag)
+local _tagged = setmetatable({}, {__mode = 'kv'})
+
+local _str_tags = setmetatable({}, {__mode = 'v'})
+
+return function(tag)
+  if type(tag) == 'string' then
+     local _tag = _str_tags[tag] or {}
+     _str_tags[tag] = _tag
+     tag = _tag
+  end
+
+  tag = tag or {}
+
+  if _tagged[tag] then
+     return _tagged[tag]
+  end
+
   local coroutine = {
     isyieldable = isyieldable,
     running     = running,
     status      = status,
   }
-  tag = tag or {}
 
+  _tagged[tag] = coroutine
   local function for_wrap (co, ...)
     if tag == ... then
       return select (2, ...)

--- a/src/coroutine/make.lua
+++ b/src/coroutine/make.lua
@@ -12,7 +12,7 @@ local _tagged = setmetatable({}, {__mode = 'kv'})
 
 local _str_tags = setmetatable({}, {__mode = 'v'})
 
-return function(tag)
+return function (tag)
   if type(tag) == 'string' then
      local _tag = _str_tags[tag] or {}
      _str_tags[tag] = _tag


### PR DESCRIPTION
This changes the library so that string tags are auto-converted into a private table, and so that the return `coroutine` table is cached by tag. 

The combination means that a user can get a consistent set of nested coroutine tools by string, from any module:

```lua
local coro = coromake 'scheduler'
```

Will return the same `coro` for any unique string, without causing trouble if that string is yielded by this or another `yield` function.

The alternative in the original code would involve either making global or passing around, some common table used only for this purpose, or choosing some metatable or function deemed unlikely to be used, and hoping we don't forget.

The original code also allows a string argument, but then will exhibit strange behavior if that string is yielded, ever, and that's the sort of bug no one wants to have. The semantics are unchanged if the argument isn't a string, and I would argue that what this patch does with strings is safer and more convenient.